### PR TITLE
Use supervisorctl conf in etc

### DIFF
--- a/serverscripts/checkouts.py
+++ b/serverscripts/checkouts.py
@@ -426,12 +426,14 @@ def main():
                 except:  # Bare except.
                     logger.exception("Error calling %s", svc_command)
             elif len(confs) == 0:
-                logger.exception("No supervisorctl configuration found")
+                logger.exception("No supervisorctl configuration found in %s",
+                                 etc_directory)
             else:
-                logger.exception("Multiple ({}) supervisorctl configurations "
-                                 "found".format(len(confs)))
+                logger.exception("Multiple supervisorctl configurations "
+                                 "found in %s", etc_directory)
         else:
-            logger.debug("No supervisorctl script found in %s", directory)
+            logger.debug("No supervisorctl script or etc directory found in "
+                         "%s", directory)
 
         result[name] = checkout
 


### PR DESCRIPTION
@byrman  Ik heb de vorige getest op s-web-ws-d9, alles doet het behalve de supervisorctl info. Deze heb ik nog even gefixt.

Over deployen: ik heb nu de sdist met SCP naar s-web-ws-d9 gekopieerd en geinstalleerd met pip als root. Een handmatige checkout-info geeft de juiste 'facts' weer in /var/local. Alleen op een of andere manier pakt serverinfo.lizard.net het nog niet goed op. Na een automatische run van checkount-info lijkt het alsof de vorige versie van 1.4 nog aanwezig is.