### PR TITLE
cd to pipenv dir before running commands (and os.stat on manage.py) there

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of serverscripts
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change directory to a pipenv-managed directory before running commands
+  there.
 
 
 1.7.0 (2019-08-27)

--- a/serverscripts/checkouts.py
+++ b/serverscripts/checkouts.py
@@ -246,6 +246,8 @@ def django_info_buildout(bin_django):
 
 
 def django_info_pipenv(directory):
+    original_dir = os.getcwd()
+    os.chdir(directory)
     matplotlibenv = "MPLCONFIGDIR=/tmp"
     # ^^^ Corner case when something needs matplotlib in django's settings.
     target_user_id = os.stat("manage.py").st_uid
@@ -257,6 +259,7 @@ def django_info_pipenv(directory):
         django_script,
     )
     output, error = get_output(command, cwd=directory, fail_on_exit_code=False)
+    os.chdir(original_dir)
     if error:
         logger.warning("Error output from diffsettings command: %s", error)
         if not output:


### PR DESCRIPTION
@caspervdw: this probably fixes the problem that serverinfo doesn't update for lizard.
The `os.stat("manage.py")` failed and caused the django information not to be updated.