### PR TITLE
[Done] Extend docker-info

### DIFF
--- a/serverscripts/checkouts.py
+++ b/serverscripts/checkouts.py
@@ -196,7 +196,7 @@ def whereis(name):
             return executable
 
 
-def _parse_python_version(output, error):
+def parse_python_version(output, error):
     match = PYTHON_VERSION.match((output + error).replace("\n", ""))
     if match is None:
         python_version = "UNKNOWN"
@@ -206,7 +206,7 @@ def _parse_python_version(output, error):
     return python_version
 
 
-def _parse_freeze(output):
+def parse_freeze(output):
     pkgs = dict()
     for pkg in output.split("\n"):
         if len(pkg) == 0:
@@ -233,10 +233,10 @@ def pipenv_info(directory):
         return
 
     output, error = get_output(pipenv + " run pip freeze --all", cwd=directory)
-    pkgs = _parse_freeze(output)
+    pkgs = parse_freeze(output)
 
     output, error = get_output(pipenv + " run python --version", cwd=directory)
-    pkgs["python"] = _parse_python_version(output, error)
+    pkgs["python"] = parse_python_version(output, error)
     return pkgs
 
 
@@ -245,10 +245,10 @@ def venv_info(bin_dir):
         bin_dir += "/"
 
     output, error = get_output(bin_dir + "pip freeze --all")
-    pkgs = _parse_freeze(output)
+    pkgs = parse_freeze(output)
 
     output, error = get_output(bin_dir + "python --version")
-    pkgs["python"] = _parse_python_version(output, error)
+    pkgs["python"] = parse_python_version(output, error)
     return pkgs
 
 

--- a/serverscripts/docker.py
+++ b/serverscripts/docker.py
@@ -7,10 +7,8 @@ import serverscripts
 import sys
 
 from serverscripts.utils import get_output
-from serverscripts.checkouts import (
-    parse_freeze,
-    parse_python_version,
-)
+from serverscripts.checkouts import parse_freeze
+from serverscripts.checkouts import parse_python_version
 
 
 VAR_DIR = "/var/local/serverscripts"

--- a/serverscripts/docker.py
+++ b/serverscripts/docker.py
@@ -168,7 +168,3 @@ def main():
         open(zabbix_file2, "w").write(str(info_on_docker["active_containers"]))
         zabbix_file3 = os.path.join(VAR_DIR, "nens.num_active_docker_volumes.info")
         open(zabbix_file3, "w").write(str(info_on_docker["active_volumes"]))
-
-
-if __name__ == "__main__":
-    main()

--- a/serverscripts/docker.py
+++ b/serverscripts/docker.py
@@ -30,11 +30,11 @@ DOCKER_PS_FIELDS = (
     "CreatedAt",
     "RunningFor",
     "Ports",
-    "State",
+    # "State",  errors on older docker
     "Status",
     "Size",
     "Names",
-    # "Labels",
+    # "Labels",  very long field
     "Mounts",
     "Networks",
 )
@@ -78,8 +78,12 @@ def python_details(container):
         if python_exec in split_command:
             break
     else:
-        # it is some other command probably using:
-        python_exec = "python3"
+        # it is some other command (gunicorn; bin/gunicorn)
+        dirname = os.path.dirname(split_command[0])
+        if dirname == "":
+            python_exec = "python3"  # global default
+        else:
+            python_exec = os.path.join(dirname, "python")
     python_in_docker = "docker exec " + container["id"] + " " + python_exec + " "
 
     # identify the python version

--- a/serverscripts/docker.py
+++ b/serverscripts/docker.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import serverscripts
-import subprocess
 import sys
 
 from serverscripts.utils import get_output

--- a/serverscripts/docker.py
+++ b/serverscripts/docker.py
@@ -10,7 +10,6 @@ from serverscripts.utils import get_output
 from serverscripts.checkouts import (
     parse_freeze,
     parse_python_version,
-    parse_django_info,
 )
 
 

--- a/serverscripts/docker.py
+++ b/serverscripts/docker.py
@@ -49,15 +49,6 @@ PYTHON_EXEC_OPTIONS = (
     "/usr/bin/python",
     "/usr/bin/python3",
 )
-# recognize a python docker by the presence of one of these in the command
-# the interpreter is guessed to be "python3"
-OTHER_PYTHON_COMMANDS = (
-    "./manage.py",
-    "/code/manage.py",
-    "gunicorn",
-    "uvicorn",
-    "celery",
-)
 DOCKER_EXEC_ERROR = "OCI runtime exec failed:"
 
 logger = logging.getLogger(__name__)
@@ -92,7 +83,7 @@ def python_details(container):
         "Running %s %s in container '%s'..", python_exec, command, container["names"]
     )
     output, _ = get_output(python_in_docker + command, fail_on_exit_code=False)
-    if output.startswith(DOCKER_EXEC_ERROR):
+    if output.startswith(DOCKER_EXEC_ERROR) or output.startswith("Traceback"):
         logger.info("Did not find Python in docker %s", container["names"])
         return {}
     python_version = parse_python_version(output, "")

--- a/serverscripts/tests/test_docker.py
+++ b/serverscripts/tests/test_docker.py
@@ -17,18 +17,19 @@ cca6ed94102fa749cd32cb289cde07d38323380697a87f6c6334de9715caac76	harbor.lizard.n
 """
 
 class DockerTestCase(TestCase):
-    @mock.patch("subprocess.Popen.communicate")
+    @mock.patch("serverscripts.docker.get_output")
     @mock.patch("serverscripts.docker.container_details")
-    def test_all_info(self, mock_details, mock_communicate):
-        mock_communicate.return_value = (REGULAR_OUTPUT, "")
-        mock_details.return_value = ["foo", "bar"]
+    @mock.patch("serverscripts.docker.python_details")
+    def test_all_info(self, mock_python, mock_details, mock_output):
+        mock_output.return_value = (REGULAR_OUTPUT, "")
+        mock_details.return_value = [{"id": "123", "command": "run"}]
         result = docker.all_info()
         self.assertEqual(3, result["active_volumes"])
         self.assertIs(mock_details.return_value, result["containers"])
 
-    @mock.patch("subprocess.Popen.communicate")
-    def test_container_details(self, mock_communicate):
-        mock_communicate.return_value = (DOCKER_PS_OUTPUT, "")
+    @mock.patch("serverscripts.docker.get_output")
+    def test_container_details(self, mock_output):
+        mock_output.return_value = (DOCKER_PS_OUTPUT, "")
         result = docker.container_details()
         self.assertEqual(2, len(result))
         self.assertEqual(result[0]["command"], "\"python manage.py runserver 0.0.0.0:8000\"")

--- a/serverscripts/tests/test_docker.py
+++ b/serverscripts/tests/test_docker.py
@@ -11,10 +11,25 @@ Containers          2                   2                   70 B                
 Local Volumes       3                   3                   123 MB              0 B (0%)
 """
 
+DOCKER_PS_OUTPUT = """
+cca6ed94102fa749cd32cb289cde07d38323380697a87f6c6334de9715caac76	harbor.lizard.net/threedi/threedi_api	"python manage.py runserver 0.0.0.0:8000"	2021-04-29 12:17:30 +0200 CEST	5 days ago0.0.0.0:8000->8000/tcp, :::8000->8000/tcp	running	Up 51 minutes	430kB (virtual 866MB)	threedi-api_api_1	/home/casper/code/threedi-api/threedi-api,/home/casper/code/threedi-api/docker-compose.yml	threedi_backend
+9d6dda1ad3054870b157252c3ceb752a67d5382430b8d37a9d40b72db83f2777	minio/minio:RELEASE.2020-10-03T02-19-42Z	"/usr/bin/docker-entrypoint.sh server /export"	2021-04-15 13:42:06 +0200 CEST	2 weeks ago	0.0.0.0:9000->9000/tcp, :::9000->9000/tcp	running	Up 51 minutes	0B (virtual 62.4MB)	threedi-api_minio_1	1c18c1163d44b55769f5090b8ae12fff8c3f970f63007d98b5130b1fdaaebab5,threedi-api_miniodata	threedi_backend
+"""
 
 class DockerTestCase(TestCase):
-    def test_all_info(self):
-        with mock.patch("subprocess.Popen.communicate") as mock_communicate:
-            mock_communicate.return_value = (REGULAR_OUTPUT, "")
-            result = docker.all_info()
-            self.assertEqual(3, result["active_volumes"])
+    @mock.patch("subprocess.Popen.communicate")
+    @mock.patch("serverscripts.docker.container_details")
+    def test_all_info(self, mock_details, mock_communicate):
+        mock_communicate.return_value = (REGULAR_OUTPUT, "")
+        mock_details.return_value = ["foo", "bar"]
+        result = docker.all_info()
+        self.assertEqual(3, result["active_volumes"])
+        self.assertIs(mock_details.return_value, result["containers"])
+
+    @mock.patch("subprocess.Popen.communicate")
+    def test_container_details(self, mock_communicate):
+        mock_communicate.return_value = (DOCKER_PS_OUTPUT, "")
+        result = docker.container_details()
+        self.assertEqual(2, len(result))
+        self.assertEqual(result[0]["command"], "\"python manage.py runserver 0.0.0.0:8000\"")
+        self.assertEqual(result[1]["size"], "0B (virtual 62.4MB)")

--- a/serverscripts/tests/test_docker.py
+++ b/serverscripts/tests/test_docker.py
@@ -12,8 +12,8 @@ Local Volumes       3                   3                   123 MB              
 """
 
 DOCKER_PS_OUTPUT = """
-cca6ed94102fa749cd32cb289cde07d38323380697a87f6c6334de9715caac76	harbor.lizard.net/threedi/threedi_api	"python manage.py runserver 0.0.0.0:8000"	2021-04-29 12:17:30 +0200 CEST	5 days ago0.0.0.0:8000->8000/tcp, :::8000->8000/tcp	running	Up 51 minutes	430kB (virtual 866MB)	threedi-api_api_1	/home/casper/code/threedi-api/threedi-api,/home/casper/code/threedi-api/docker-compose.yml	threedi_backend
-9d6dda1ad3054870b157252c3ceb752a67d5382430b8d37a9d40b72db83f2777	minio/minio:RELEASE.2020-10-03T02-19-42Z	"/usr/bin/docker-entrypoint.sh server /export"	2021-04-15 13:42:06 +0200 CEST	2 weeks ago	0.0.0.0:9000->9000/tcp, :::9000->9000/tcp	running	Up 51 minutes	0B (virtual 62.4MB)	threedi-api_minio_1	1c18c1163d44b55769f5090b8ae12fff8c3f970f63007d98b5130b1fdaaebab5,threedi-api_miniodata	threedi_backend
+cca6ed94102fa749cd32cb289cde07d38323380697a87f6c6334de9715caac76	harbor.lizard.net/threedi/threedi_api	"python manage.py runserver 0.0.0.0:8000"	2021-04-29 12:17:30 +0200 CEST	5 days ago0.0.0.0:8000->8000/tcp, :::8000->8000/tcp	Up 51 minutes	430kB (virtual 866MB)	threedi-api_api_1	/home/casper/code/threedi-api/threedi-api,/home/casper/code/threedi-api/docker-compose.yml	threedi_backend
+9d6dda1ad3054870b157252c3ceb752a67d5382430b8d37a9d40b72db83f2777	minio/minio:RELEASE.2020-10-03T02-19-42Z	"/usr/bin/docker-entrypoint.sh server /export"	2021-04-15 13:42:06 +0200 CEST	2 weeks ago	0.0.0.0:9000->9000/tcp, :::9000->9000/tcp	Up 51 minutes	0B (virtual 62.4MB)	threedi-api_minio_1	1c18c1163d44b55769f5090b8ae12fff8c3f970f63007d98b5130b1fdaaebab5,threedi-api_miniodata	threedi_backend
 """
 
 class DockerTestCase(TestCase):


### PR DESCRIPTION
This adds a list of details of the running containers to the docker-info.

If some python interpreter is in the "command" of the docker, then ``python --version`` and ``python -m pip freeze --all`` are done. ~If manage.py is in the "command" , then also ``python manage.py diffsettings``~

Everything ends up in a data structure like this (on my machine):

```
{
    "active": true,
    "available": true,
    "containers": [
        {
            "command": "\"python manage.py runserver 0.0.0.0:8000\"",
            "createdat": "2021-04-29 12:17:30 +0200 CEST",
            "id": "cca6ed94102fa749cd32cb289cde07d38323380697a87f6c6334de9715caac76",
            "image": "harbor.lizard.net/threedi/threedi_api",
            "mounts": "/home/casper/code/threedi-api/threedi-api,/home/casper/code/threedi-api/docker-compose.yml",
            "names": "threedi-api_api_1",
            "networks": "threedi_backend",
            "ports": "0.0.0.0:8000->8000/tcp, :::8000->8000/tcp",
            "python": {
                "eggs": {
                    "Automat": "20.2.0",
                    "Babel": "2.9.1",
                    "Django": "3.1.6",
                    "Faker": "8.1.1",
                    "Jinja2": "2.11.3",
                    "Markdown": "3.2.2",
                    "MarkupSafe": "1.1.1",
                    "Pint": "0.9",
                    "PyHamcrest": "2.0.2",
                    "PyJWT": "1.7.1",
                    "PyYAML": "5.3.1",
                    "Pygments": "2.8.1",
                    "Sphinx": "1.7.1",
                    "Twisted": "20.3.0",
                    "aiohttp": "3.7.4.post0",
                    "aioredis": "1.3.1",
                    "alabaster": "0.7.12",
                    "appdirs": "1.4.4",
                    "argh": "0.26.2",
                    "asgiref": "3.3.1",
                    "async-timeout": "3.0.1",
                    "attrs": "19.3.0",
                    "autobahn": "21.3.1",
                    "backcall": "0.2.0",
                    "backoff": "1.10.0",
                    "bumpversion": "0.5.3",
                    "cachetools": "4.2.2",
                    "certifi": "2020.12.5",
                    "cffi": "1.14.5",
                    "channels": "2.3.1",
                    "channels-redis": "3.2.0",
                    "chardet": "3.0.4",
                    "constantly": "15.1.0",
                    "conu": "0.7.1",
                    "coreapi": "2.3.3",
                    "coreschema": "0.0.4",
                    "coverage": "4.5.3",
                    "cryptography": "3.4.7",
                    "daphne": "2.5.0",
                    "debugpy": "1.2.1",
                    "decorator": "5.0.7",
                    "distlib": "0.3.1",
                    "django-appconf": "1.0.3",
                    "django-cors-headers": "3.1.0",
                    "django-crispy-forms": "1.9.2",
                    "django-debug-toolbar": "2.2",
                    "django-extensions": "3.0.5",
                    "django-filter": "2.3.0",
                    "django-redis": "4.12.1",
                    "django-taggit": "1.3.0",
                    "djangorestframework": "3.12.2",
                    "djangorestframework-gis": "0.15",
                    "djangorestframework-simplejwt": "4.4.0",
                    "docker": "5.0.0",
                    "docutils": "0.17.1",
                    "drf-yasg": "1.20.0",
                    "factory-boy": "3.2.0",
                    "filelock": "3.0.12",
                    "flake8": "3.5.0",
                    "google-auth": "1.30.0",
                    "gunicorn": "20.0.4",
                    "h11": "0.8.1",
                    "h2": "3.2.0",
                    "hiredis": "2.0.0",
                    "hpack": "3.0.0",
                    "http3": "0.6.7",
                    "humanize": "2.6.0",
                    "hyperframe": "5.2.0",
                    "hyperlink": "21.0.0",
                    "idna": "2.10",
                    "imagesize": "1.2.0",
                    "incremental": "21.3.0",
                    "inflection": "0.5.1",
                    "iniconfig": "1.1.1",
                    "ipdb": "0.13.3",
                    "ipython": "7.17.0",
                    "ipython-genutils": "0.2.0",
                    "iso8601": "0.1.12",
                    "itsdangerous": "1.1.0",
                    "itypes": "1.2.0",
                    "jedi": "0.17.2",
                    "jsonschema": "3.2.0",
                    "kubernetes": "12.0.1",
                    "lizard-auth-client": "3.0.5",
                    "lz4": "2.1.6",
                    "mccabe": "0.6.1",
                    "minio": "4.0.14",
                    "mock": "4.0.2",
                    "msgpack": "1.0.2",
                    "multidict": "5.1.0",
                    "namesgenerator": "0.3",
                    "oauthlib": "3.1.0",
                    "packaging": "20.9",
                    "parso": "0.7.1",
                    "pathtools": "0.1.2",
                    "pexpect": "4.8.0",
                    "pickleshare": "0.7.5",
                    "pip": "21.1",
                    "pluggy": "0.13.1",
                    "prompt-toolkit": "3.0.18",
                    "psycopg2-binary": "2.8.5",
                    "ptyprocess": "0.7.0",
                    "py": "1.10.0",
                    "pyOpenSSL": "20.0.1",
                    "pyasn1": "0.4.8",
                    "pyasn1-modules": "0.2.8",
                    "pycodestyle": "2.3.1",
                    "pycparser": "2.20",
                    "pydantic": "1.6.1",
                    "pyflakes": "1.6.0",
                    "pyparsing": "2.4.7",
                    "pyrsistent": "0.17.3",
                    "pytest": "6.2.2",
                    "pytest-asyncio": "0.14.0",
                    "pytest-cov": "2.6.1",
                    "pytest-django": "3.9.0",
                    "pytest-runner": "2.11.1",
                    "pytest-timeout": "1.4.2",
                    "python": "3.8.7",
                    "python-dateutil": "2.8.1",
                    "pytz": "2021.1",
                    "redis": "3.5.3",
                    "requests": "2.25.1",
                    "requests-async": "0.6.2",
                    "requests-oauthlib": "1.3.0",
                    "responses": "0.10.16",
                    "rfc3986": "1.4.0",
                    "rsa": "4.7.2",
                    "ruamel.yaml": "0.17.4",
                    "ruamel.yaml.clib": "0.2.2",
                    "sentry-sdk": "0.19.5",
                    "service-identity": "18.1.0",
                    "setuptools": "53.0.0",
                    "six": "1.15.0",
                    "snowballstemmer": "2.1.0",
                    "sphinxcontrib-serializinghtml": "1.1.4",
                    "sphinxcontrib-websupport": "1.2.4",
                    "sqlparse": "0.4.1",
                    "swagger-spec-validator": "2.7.3",
                    "text-unidecode": "1.3",
                    "threedi-api-client": "3.0.26",
                    "toml": "0.10.2",
                    "tox": "2.9.1",
                    "traitlets": "5.0.5",
                    "txaio": "21.2.1",
                    "typing-extensions": "3.7.4.3",
                    "uritemplate": "3.0.1",
                    "urllib3": "1.26.4",
                    "virtualenv": "20.4.4",
                    "watchdog": "0.8.3",
                    "wcwidth": "0.2.5",
                    "websocket-client": "0.58.0",
                    "wheel": "0.30.0",
                    "yarl": "1.6.3",
                    "zope.interface": "5.4.0"
                }
            },
            "runningfor": "6 days ago",
            "size": "436kB (virtual 866MB)",
            "state": "running",
            "status": "Up 5 hours"
        },
        {
            "command": "\"/usr/bin/docker-entrypoint.sh server /export\"",
            "createdat": "2021-04-15 13:42:06 +0200 CEST",
            "id": "9d6dda1ad3054870b157252c3ceb752a67d5382430b8d37a9d40b72db83f2777",
            "image": "minio/minio:RELEASE.2020-10-03T02-19-42Z",
            "mounts": "1c18c1163d44b55769f5090b8ae12fff8c3f970f63007d98b5130b1fdaaebab5,threedi-api_miniodata",
            "names": "threedi-api_minio_1",
            "networks": "threedi_backend",
            "ports": "0.0.0.0:9000->9000/tcp, :::9000->9000/tcp",
            "python": {},
            "runningfor": "2 weeks ago",
            "size": "0B (virtual 62.4MB)",
            "state": "running",
            "status": "Up 5 hours"
        },
        {
            "command": "\"docker-entrypoint.sh redis-server\"",
            "createdat": "2021-04-15 13:09:40 +0200 CEST",
            "id": "2ca44646b168711a2cee4c956676929e20e2565ac0bb18f84a0ea5230063e03e",
            "image": "redis:5.0.3-alpine",
            "mounts": "753eb86e6d3b60ee38252609cf26c307bae92ccc83e6383339241f5500354ae1",
            "names": "threedi-api_global-redis_1",
            "networks": "threedi_backend",
            "ports": "6380/tcp, 0.0.0.0:6380->6379/tcp, :::6380->6379/tcp",
            "python": {},
            "runningfor": "2 weeks ago",
            "size": "0B (virtual 50.8MB)",
            "state": "running",
            "status": "Up 5 hours"
        },
        {
            "command": "\"docker-entrypoint.sh postgres\"",
            "createdat": "2021-04-15 13:09:40 +0200 CEST",
            "id": "b5c4c0841a6d8acfc631b1374cb854e3b47c83e4a60b0b0c0a045a530ee46a00",
            "image": "threedi-api_db",
            "mounts": "threedi-api_pgdata",
            "names": "threedi-api_db_1",
            "networks": "threedi_backend",
            "ports": "5432/tcp",
            "python": {},
            "runningfor": "2 weeks ago",
            "size": "63B (virtual 299MB)",
            "state": "running",
            "status": "Up 5 hours"
        },
        {
            "command": "\"docker-entrypoint.sh sh -c 'rm -f /data/dump.rdb && redis-server --save '''\"",
            "createdat": "2021-04-15 13:09:40 +0200 CEST",
            "id": "9b4f7c1852abdd4e881a945637d454e274c895ebc91881e3e5b583cfeaac39e8",
            "image": "redis:5.0.3-alpine",
            "mounts": "d621b78ef1757c68fbfa04aeffa6c300d49fd2f0d2dc2df3e639d8c876b5449c",
            "names": "threedi-api_redis_1",
            "networks": "threedi_backend",
            "ports": "0.0.0.0:6379->6379/tcp, :::6379->6379/tcp",
            "python": {},
            "runningfor": "2 weeks ago",
            "size": "0B (virtual 50.8MB)",
            "state": "running",
            "status": "Up 5 hours"
        }
    ]
```