### PR TITLE
Fixed checkoutinfo crash when there's a 'main' branch instead of 'master'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of serverscripts
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed checkoutinfo crash when there's a 'main' branch instead of 'master'.
 
 
 1.9.0 (2021-05-05)

--- a/serverscripts/checkouts.py
+++ b/serverscripts/checkouts.py
@@ -114,6 +114,9 @@ def git_info(directory):
     if "master" in output:
         data["release"] = "master"
         logger.debug("It is a master checkout")
+    elif "main" in output:
+        data["release"] = "main"
+        logger.debug("It is a 'main' checkout")
     else:
         output, error = get_output("git describe", cwd=directory)
         first_line = output.split("\n")[0]


### PR DESCRIPTION
I noticed the problem on p-project-task-d1.

The 'main' branch wasn't detected as master-like, so checkoutinfo did a "git describe", which doesn't give a result when there's no tag checkout.