### PR TITLE
Fix parsing of pip freeze output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog of serverscripts
 1.9.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed editable packages in docker containers without git.
 
 
 1.9.1 (2021-05-05)

--- a/serverscripts/checkouts.py
+++ b/serverscripts/checkouts.py
@@ -216,7 +216,9 @@ def parse_freeze(output):
             continue
         if pkg.startswith("-e"):
             match = EDITABLE_PKG.match(pkg)
-            pkgs[match.group("project")] = match.group("ref")
+            if match is not None:
+                pkgs["-e " + match.group("project")] = match.group("ref")
+                continue
         pkg = pkg.split("==")  # name==version
         if len(pkg) != 2:
             # invalid spec

--- a/serverscripts/tests/test_checkouts.py
+++ b/serverscripts/tests/test_checkouts.py
@@ -14,6 +14,17 @@ OUR_PYTHON_VERSION = "%s.%s.%s" % (
 )
 
 
+def test_parse_pip_freeze_with_error():
+    to_parse = "ERROR: foo\nWARNING: bar\nappdirs==1.4.4\n-e sso==2.18.dev0"
+    to_parse += "\n-e git+git@github.com:nens/repo.git@master#egg=repo"
+    actual = checkouts.parse_freeze(to_parse)
+    assert actual == {
+        "appdirs": "1.4.4",
+        "-e sso": "2.18.dev0",
+        "-e repo": "master",
+    }
+
+
 class VenvPipenvTestCase(TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
On sso.lizard.net, we have  "-e sso=2.18.dev0" in the output. Normally pip freeze would show the git ref there, but there is not git installed in the container.

The script here expects a git ref, so it crashes with

```
  File "/usr/local/lib/python3.5/dist-packages/serverscripts/checkouts.py", line 219, in parse_freeze
    pkgs[match.group("project")] = match.group("ref")
AttributeError: 'NoneType' object has no attribute 'group'
```